### PR TITLE
Fixes a bug when a node is disconnected ungracefully from a two node cluster

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -811,6 +811,7 @@ func (c *Cluster) repairLeafset(id NodeID) error {
 	if err != nil {
 		if err == nodeNotFoundError {
 			c.warn("No node found when trying to repair the leafset. Was there a catastrophe?")
+			return nil
 		} else {
 			return err
 		}


### PR DESCRIPTION
The bug is that the disconnected node seems to hang around in the
neighborhood set but not in the leafset.

It seems like a single cluster does not record itself in the leafset. So
when the leafset is repaired, it doesn't find the "next node" and
complains. But the function continues and the `send` ends up failing.
This results in the neighborhoodset never being updated/repaired.

My solution was to simply return nil when repairing an empty leafset.
